### PR TITLE
CertiK 2nd audit fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ npm run genabi
 | CoFiXVaultForCNode | 0x1a31b517ABF0D2F4f11A797d7b8622859429AA25 |
 | CoFiStakingRewards | 0xDe80d5423569Ea4104d127e14E3fC1BE0486531d |
 
+- ETH/USDT
+  - Pair (XToken): 0x5f22a04F81A87a7aBe9191C338fA5Ba092Af4562
+  - XToken StakingRewards Pool: 0xA3904574E4Fbf7592B3A3c1439cAe97D5622FBFD
+- ETH/HBTC
+  - Pair (XToken): 0x9D90e9e5AFF7545046FF66544B7848C21118Da22
+  - XToken StakingRewards Pool: 0xe6c3bd6D258cE7fc7554723fc2b93F848CEF30E7
+
 <!-- ### Beta-V0.1
 
 |       Contract       |                  Address                   |

--- a/contracts/CNodeStakingRewards.sol
+++ b/contracts/CNodeStakingRewards.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity ^0.6.6;
+pragma solidity 0.6.12;
 
 import "./interface/ICoFiXVaultForCNode.sol";
 import "./CoFiXStakingRewards.sol";

--- a/contracts/CoFiStakingRewards.sol
+++ b/contracts/CoFiStakingRewards.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity ^0.6.6;
+pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "./lib/TransferHelper.sol";

--- a/contracts/CoFiXPair.sol
+++ b/contracts/CoFiXPair.sol
@@ -16,7 +16,6 @@ contract CoFiXPair is ICoFiXPair, CoFiXERC20 {
 
     enum CoFiX_OP { QUERY, MINT, BURN, SWAP_WITH_EXACT, SWAP_FOR_EXACT } // operations in CoFiX
 
-    uint public override constant MINIMUM_LIQUIDITY = 10**3;
     bytes4 private constant SELECTOR = bytes4(keccak256(bytes("transfer(address,uint256)")));
 
     uint256 constant public K_BASE = 1E8; // K

--- a/contracts/CoFiXStakingRewards.sol
+++ b/contracts/CoFiXStakingRewards.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity ^0.6.6;
+pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "./lib/TransferHelper.sol";

--- a/contracts/CoFiXVaultForLP.sol
+++ b/contracts/CoFiXVaultForLP.sol
@@ -45,6 +45,11 @@ contract CoFiXVaultForLP is ICoFiXVaultForLP, ReentrancyGuard {
 
     mapping (address => address) public pairToStakingPool; // pair -> staking pool
 
+    modifier onlyGovernance() {
+        require(msg.sender == governance, "CVaultForLP: !governance");
+        _;
+    }
+
     constructor(address cofi, address _factory) public {
         cofiToken = cofi;
         factory = _factory;
@@ -53,29 +58,24 @@ contract CoFiXVaultForLP is ICoFiXVaultForLP, ReentrancyGuard {
     }
 
     /* setters for protocol governance */
-    function setGovernance(address _new) external override {
-        require(msg.sender == governance, "CVaultForLP: !governance");
+    function setGovernance(address _new) external override onlyGovernance {
         governance = _new;
     }
 
-    function setInitCoFiRate(uint256 _new) external override {
-        require(msg.sender == governance, "CVaultForLP: !governance");
+    function setInitCoFiRate(uint256 _new) external override onlyGovernance {
         initCoFiRate = _new;
     }
 
-    function setDecayPeriod(uint256 _new) external override {
-        require(msg.sender == governance, "CVaultForLP: !governance");
+    function setDecayPeriod(uint256 _new) external override onlyGovernance {
         require(_new != 0, "CVaultForLP: wrong period setting");
         decayPeriod = _new;
     }
 
-    function setDecayRate(uint256 _new) external override {
-        require(msg.sender == governance, "CVaultForLP: !governance");
+    function setDecayRate(uint256 _new) external override onlyGovernance {
         decayRate = _new;
     }
 
-    function addPool(address pool) external override {
-        require(msg.sender == governance, "CVaultForLP: !governance");
+    function addPool(address pool) external override onlyGovernance {
         require(poolInfo[pool].state == POOL_STATE.INVALID, "CVaultForLP: pool added"); // INVALID -> ENABLED
         poolInfo[pool].state = POOL_STATE.ENABLED;
         // default rate is zero, to ensure safety
@@ -88,8 +88,7 @@ contract CoFiXVaultForLP is ICoFiXVaultForLP, ReentrancyGuard {
         emit NewPoolAdded(pool, allPools.length);
     }
 
-    function enablePool(address pool) external override {
-        require(msg.sender == governance, "CVaultForLP: !governance");
+    function enablePool(address pool) external override onlyGovernance {
         require(poolInfo[pool].state == POOL_STATE.DISABLED, "CVaultForLP: pool not disabled"); // DISABLED -> ENABLED
         poolInfo[pool].state = POOL_STATE.ENABLED;
         enabledCnt = enabledCnt.add(1);
@@ -100,8 +99,7 @@ contract CoFiXVaultForLP is ICoFiXVaultForLP, ReentrancyGuard {
         emit PoolEnabled(pool);
     }
 
-    function disablePool(address pool) external override {
-        require(msg.sender == governance, "CVaultForLP: !governance");
+    function disablePool(address pool) external override onlyGovernance {
         require(poolInfo[pool].state == POOL_STATE.ENABLED, "CVaultForLP: pool not enabled"); // ENABLED -> DISABLED
         poolInfo[pool].state = POOL_STATE.DISABLED;
         poolInfo[pool].weight = 0; // set pool weight to zero;
@@ -111,15 +109,13 @@ contract CoFiXVaultForLP is ICoFiXVaultForLP, ReentrancyGuard {
         emit PoolDisabled(pool);
     }
 
-    function setPoolWeight(address pool, uint256 weight) public override {
-        require(msg.sender == governance, "CVaultForLP: !governance");
+    function setPoolWeight(address pool, uint256 weight) public override onlyGovernance {
         require(weight <= WEIGHT_BASE, "CVaultForLP: invalid weight");
         require(poolInfo[pool].state == POOL_STATE.ENABLED, "CVaultForLP: pool not enabled"); // only set weight if pool is enabled
         poolInfo[pool].weight = weight;
     }
 
-    function batchSetPoolWeight(address[] memory pools, uint256[] memory weights) external override {
-        require(msg.sender == governance, "CVaultForLP: !governance");
+    function batchSetPoolWeight(address[] memory pools, uint256[] memory weights) external override onlyGovernance {
         uint256 cnt = pools.length;
         require(cnt == weights.length, "CVaultForLP: mismatch len");
         for (uint256 i = 0; i < cnt; i++) {

--- a/contracts/CoFiXVaultForTrader.sol
+++ b/contracts/CoFiXVaultForTrader.sol
@@ -58,6 +58,11 @@ contract CoFiXVaultForTrader is ICoFiXVaultForTrader, ReentrancyGuard {
     uint128 public lastMinedBlock; // last block mined cofi token
     uint128 public lastDensity; // last mining density, see currentDensity()
 
+    modifier onlyGovernance() {
+        require(msg.sender == governance, "CVaultForTrader: !governance");
+        _;
+    }
+
     constructor(address cofi, address _factory) public {
         cofiToken = cofi;
         factory = _factory;
@@ -66,20 +71,17 @@ contract CoFiXVaultForTrader is ICoFiXVaultForTrader, ReentrancyGuard {
     }
 
     /* setters for protocol governance */
-    function setGovernance(address _new) external override {
-        require(msg.sender == governance, "CVaultForTrader: !governance");
+    function setGovernance(address _new) external override onlyGovernance {
         governance = _new;
     }
 
-    function allowRouter(address router) external override {
-        require(msg.sender == governance, "CVaultForTrader: !governance");
+    function allowRouter(address router) external override onlyGovernance {
         require(!routerAllowed[router], "CVaultForTrader: router allowed");
         routerAllowed[router] = true;
         emit RouterAllowed(router);
     }
 
-    function disallowRouter(address router) external override {
-        require(msg.sender == governance, "CVaultForTrader: !governance");
+    function disallowRouter(address router) external override onlyGovernance {
         require(routerAllowed[router], "CVaultForTrader: router disallowed");
         routerAllowed[router] = false;
         emit RouterDisallowed(router);

--- a/contracts/CoFiXVaultForTrader.sol
+++ b/contracts/CoFiXVaultForTrader.sol
@@ -73,14 +73,14 @@ contract CoFiXVaultForTrader is ICoFiXVaultForTrader, ReentrancyGuard {
 
     function allowRouter(address router) external override {
         require(msg.sender == governance, "CVaultForTrader: !governance");
-        require(routerAllowed[router] == false, "CVaultForTrader: router allowed");
+        require(!routerAllowed[router], "CVaultForTrader: router allowed");
         routerAllowed[router] = true;
         emit RouterAllowed(router);
     }
 
     function disallowRouter(address router) external override {
         require(msg.sender == governance, "CVaultForTrader: !governance");
-        require(routerAllowed[router] == true, "CVaultForTrader: router disallowed");
+        require(routerAllowed[router], "CVaultForTrader: router disallowed");
         routerAllowed[router] = false;
         emit RouterDisallowed(router);
     }
@@ -209,7 +209,7 @@ contract CoFiXVaultForTrader is ICoFiXVaultForTrader, ReentrancyGuard {
         uint256 np,
         address rewardTo
     ) external override nonReentrant {
-        require(routerAllowed[msg.sender] == true, "CVaultForTrader: not allowed router");  // caution: be careful when adding new router
+        require(routerAllowed[msg.sender], "CVaultForTrader: not allowed router");  // caution: be careful when adding new router
 
         uint256 amount;
         {

--- a/contracts/CoFiXVaultForTrader.sol
+++ b/contracts/CoFiXVaultForTrader.sol
@@ -212,6 +212,8 @@ contract CoFiXVaultForTrader is ICoFiXVaultForTrader, ReentrancyGuard {
         address rewardTo
     ) external override nonReentrant {
         require(routerAllowed[msg.sender], "CVaultForTrader: not allowed router");  // caution: be careful when adding new router
+        require(pair != address(0), "CVaultForTrader: invalid pair");
+        require(rewardTo != address(0), "CVaultForTrader: invalid rewardTo");
 
         uint256 amount;
         {

--- a/contracts/CoFiXVaultForTrader.sol
+++ b/contracts/CoFiXVaultForTrader.sol
@@ -246,6 +246,7 @@ contract CoFiXVaultForTrader is ICoFiXVaultForTrader, ReentrancyGuard {
         address vaultForCNode = ICoFiXFactory(factory).getVaultForCNode();
         require(msg.sender == vaultForCNode, "CVaultForTrader: only vaultForCNode"); // caution
         // uint256 pending = pendingRewardsForCNode;
+        emit ClearPendingRewardOfCNode(pendingRewardsForCNode);
         pendingRewardsForCNode = 0; // take all, set to 0
         // ICoFiToken(cofiToken).mint(msg.sender, pending); // no need to mint from here, we can mint directly in valult
     }
@@ -254,6 +255,7 @@ contract CoFiXVaultForTrader is ICoFiXVaultForTrader, ReentrancyGuard {
     function clearPendingRewardOfLP(address pair) external override nonReentrant {
         address vaultForLP = ICoFiXFactory(factory).getVaultForLP();
         require(msg.sender == vaultForLP, "CVaultForTrader: only vaultForLP"); // caution 
+        emit ClearPendingRewardOfLP(pendingRewardsForLP[pair]);
         pendingRewardsForLP[pair] = 0; // take all, set to 0
         // ICoFiToken(cofiToken).mint(to, pending); // no need to mint from here, we can mint directly in valult
     }

--- a/contracts/interface/ICoFiXPair.sol
+++ b/contracts/interface/ICoFiXPair.sol
@@ -25,7 +25,6 @@ interface ICoFiXPair is ICoFiXERC20 {
     );
     event Sync(uint112 reserve0, uint112 reserve1);
 
-    function MINIMUM_LIQUIDITY() external pure returns (uint);
     function factory() external view returns (address);
     function token0() external view returns (address);
     function token1() external view returns (address);

--- a/contracts/interface/ICoFiXVaultForTrader.sol
+++ b/contracts/interface/ICoFiXVaultForTrader.sol
@@ -7,6 +7,9 @@ interface ICoFiXVaultForTrader {
     event RouterAllowed(address router);
     event RouterDisallowed(address router);
 
+    event ClearPendingRewardOfCNode(uint256 pendingAmount);
+    event ClearPendingRewardOfLP(uint256 pendingAmount);
+
     function setGovernance(address gov) external;
 
     function allowRouter(address router) external;

--- a/contracts/test/CoFiXStakingRewards.sol
+++ b/contracts/test/CoFiXStakingRewards.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity ^0.6.6;
+pragma solidity 0.6.12;
 
 import "../CoFiXStakingRewards.sol";
 

--- a/scripts/deployCoFiXStakingRewards.js
+++ b/scripts/deployCoFiXStakingRewards.js
@@ -3,9 +3,11 @@ const ERC20 = artifacts.require("TestERC20");
 const { BN } = require('@openzeppelin/test-helpers');
 const { web3 } = require('@openzeppelin/test-environment');
 const Decimal = require('decimal.js');
+const { expect } = require('chai');
+require('chai').should();
 
 const CoFiToken = artifacts.require("CoFiToken");
-const TestXToken = artifacts.require("TestXToken");
+const CoFiXPair = artifacts.require("CoFiXPair");
 const CoFiXVaultForLP = artifacts.require("CoFiXVaultForLP");
 const CoFiXFactory = artifacts.require("CoFiXFactory");
 const CoFiXStakingRewards = artifacts.require("CoFiXStakingRewards.sol");
@@ -19,15 +21,19 @@ module.exports = async function (callback) {
         console.log(`argv> cofi=${argv.cofi}, xtoken=${argv.xtoken}, factory=${argv.factory}, addpool=${argv.addpool}`);
 
         CoFi = await CoFiToken.at(argv.cofi);
-        XToken = await TestXToken.at(argv.xtoken);
-        CoFiXFactory = await CoFiXFactory.at(argv.factory);
+        XToken = await CoFiXPair.at(argv.xtoken);
+        CFactory = await CoFiXFactory.at(argv.factory);
 
-        const vaultForLP = await CoFiXFactory.getVaultForLP();
+        const factory = await XToken.factory();
+        console.log(`factory: ${factory}, CFactory.address: ${CFactory.address}`)
+        expect(factory).equal(CFactory.address); // verify
+
+        const vaultForLP = await CFactory.getVaultForLP();
         console.log("vaultForLP:", vaultForLP);
 
         VaultForLP = await CoFiXVaultForLP.at(vaultForLP);
 
-        StakingRewards = await CoFiXStakingRewards.new(CoFi.address, XToken.address, CoFiXFactory.address);
+        StakingRewards = await CoFiXStakingRewards.new(CoFi.address, XToken.address, CFactory.address);
     
         console.log("new CoFiXStakingRewards deployed at:", StakingRewards.address);
 


### PR DESCRIPTION
| CertiK Exhibits                                    | Responses                                                    |
| -------------------------------------------------- | ------------------------------------------------------------ |
| 1. Unlock solidity version                         | https://github.com/Computable-Finance/CoFiX/pull/5/commits/4d45edbf4ed5bfff4414ef4b85e8e6228dbffca3 |
| 2. State variables that could be declared constant | https://github.com/Computable-Finance/CoFiX/blob/2950bb6a9910ee6121df1a5206c598af1c3a7aa4/contracts/CoFiXVaultForTrader.sol#L26-L42 Most state variables are constant now |
| 3. Add “emit event” in important functions         | https://github.com/Computable-Finance/CoFiX/pull/5/commits/e37ce453099be4f4fb89cc8d20bfbff858893a2f |
| 4. Compares to a boolean constant                  | We do not compare to a boolean constant now in CoFiXVaultForLP after updating. |
| 5. Simplifying Existing Code                       | https://github.com/Computable-Finance/CoFiX/pull/5/commits/a4d658e87969780e716d5c65f7ee416fa08dbe62 |
| 6. Conﬁrm calculation formula                      | https://github.com/Computable-Finance/Doc/blob/master/README.md#72-details-about-the-trading-mining Please check section 7.2 |
| 7. Greater-Than Comparison with Zero               | https://github.com/Computable-Finance/CoFiX/commit/40c2d6cedc4b0fbaadfc8de3433c2616662632b6 |
| 8. Question about the function “currentCoFiRate”   | The latest version implemented the section 7.1  https://github.com/Computable-Finance/CoFiX/blob/2950bb6a9910ee6121df1a5206c598af1c3a7aa4/contracts/CoFiXVaultForTrader.sol#L111 |
| 9. Use of function stakeForOther                   | The `stakeForOther` is used in `CoFiXRouter::addLiquidityAndStake` which provides a shortcut for users to provide liquidity and stake to staking rewards pool directly. |
| 10. Use of function addReward                      | The `addReward` func is used to add reward from trading pool or anyone else in the future. Rewards are distributed to `totalSupply` and added to `rewardPerTokenStored`. |